### PR TITLE
Docs - Fix typos in README, web-playwright test

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ See the [modules](modules) directory.
 
 # Development
 
-Install lerna globally, then use `npm build`. Each module can be developed independantly using `npm run tsc-watch` and `npm test` options.
+Install lerna globally, then use `npm run build`. Each module can be developed independantly using `npm run tsc-watch` and `npm test` options.

--- a/modules/web-playwright/src/web-playwright.test.ts
+++ b/modules/web-playwright/src/web-playwright.test.ts
@@ -24,7 +24,7 @@ describe('playwrightWeb', () => {
     webPlaywright.finish();
   });
   it('fails setting browser type and device', async () => {
-    const { world, vstep } = await getTestEnv(stxt, 'using nonexistant browser', getDefaultWorld(0).world);
+    const { world, vstep } = await getTestEnv(stxt, 'using nonexistent browser', getDefaultWorld(0).world);
     const result = await Executor.doFeatureStep(vstep, world);
     expect(result.actionResults[0].ok).toBe(false);
   });


### PR DESCRIPTION
### Summary
- Fixes typo in web-playwright test
- Adds missing verb for npm script in documentation