### PR TITLE
chore: sync all modules to 3.9.1 baseline

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/core",
   "type": "module",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "",
   "author": "",
   "exports": {

--- a/modules/core/src/currentVersion.ts
+++ b/modules/core/src/currentVersion.ts
@@ -1,1 +1,1 @@
-export const currentVersion = '3.8.4';
+export const currentVersion = '3.9.1';

--- a/modules/domain-storage/package.json
+++ b/modules/domain-storage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/domain-storage",
   "type": "module",
-  "version": "3.8.4",
+  "version": "3.9.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/modules/lsp/package.json
+++ b/modules/lsp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/lsp",
   "type": "module",
-  "version": "3.8.4",
+  "version": "3.9.1",
   "description": "Language Server Protocol stepper for Haibun IDE integration",
   "main": "build/lsp-stepper.js",
   "files": [

--- a/modules/monitor-browser/package.json
+++ b/modules/monitor-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haibun/monitor-browser",
-  "version": "3.8.4",
+  "version": "3.9.1",
   "description": "React-based browser monitor for Haibun with shadcn/ui",
   "main": "build/index.js",
   "type": "module",

--- a/modules/monitor-otel/package.json
+++ b/modules/monitor-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haibun/monitor-otel",
-  "version": "3.8.4",
+  "version": "3.9.1",
   "description": "OpenTelemetry monitor for Haibun - exports traces and logs via OTLP",
   "main": "build/index.js",
   "files": [

--- a/modules/monitor-tui/package.json
+++ b/modules/monitor-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haibun/monitor-tui",
-  "version": "3.8.4",
+  "version": "3.9.1",
   "description": "Ink-based TUI monitor stepper for Haibun",
   "main": "build/index.js",
   "type": "module",

--- a/modules/out-junit/package.json
+++ b/modules/out-junit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/out-junit",
   "type": "module",
-  "version": "3.8.4",
+  "version": "3.9.1",
   "description": "",
   "files": [
     "build/**"

--- a/modules/storage-fs/package.json
+++ b/modules/storage-fs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/storage-fs",
   "type": "module",
-  "version": "3.8.4",
+  "version": "3.9.1",
   "description": "",
   "main": "index.js",
   "files": [

--- a/modules/storage-mem/package.json
+++ b/modules/storage-mem/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/storage-mem",
   "type": "module",
-  "version": "3.8.4",
+  "version": "3.9.1",
   "description": "",
   "main": "index.js",
   "files": [

--- a/modules/utils/package.json
+++ b/modules/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/utils",
   "type": "module",
-  "version": "3.8.4",
+  "version": "3.9.1",
   "description": "",
   "main": "index.js",
   "files": [

--- a/modules/web-accessibility-axe/package.json
+++ b/modules/web-accessibility-axe/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/web-accessibility-axe",
   "type": "module",
-  "version": "3.8.4",
+  "version": "3.9.1",
   "description": "",
   "main": "./build/a11y-axe-stepper.js",
   "exports": {

--- a/modules/web-http/package.json
+++ b/modules/web-http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/web-http",
   "type": "module",
-  "version": "3.8.4",
+  "version": "3.9.1",
   "description": "",
   "main": "build/web-http.js",
   "files": [

--- a/modules/web-playwright/package.json
+++ b/modules/web-playwright/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/web-playwright",
   "type": "module",
-  "version": "3.8.4",
+  "version": "3.9.1",
   "description": "",
   "main": "build/web-playwright.js",
   "exports": {
@@ -31,6 +31,5 @@
     "zod": "^4.3.6"
   },
   "gitHead": "7cf9680bd922fb622fb59f1e6bf5b65284cb8fd5",
-  "devDependencies": {
-  }
+  "devDependencies": {}
 }

--- a/modules/web-server-hono/package.json
+++ b/modules/web-server-hono/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/web-server-hono",
   "type": "module",
-  "version": "3.8.4",
+  "version": "3.9.1",
   "description": "Hono-based web server for haibun with MCP support",
   "main": "build/web-server-stepper.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "depcruise": "depcruise -c .dependency-cruiser.cjs -T dot modules | dot -T svg | depcruise-wrap-stream-in-html > dependency-graph.html",
     "preversion": "npm run test"
   },
-  "version": "3.8.4",
+  "version": "3.9.1",
   "overrides": {
     "react": "^19.2.3",
     "react-dom": "^19.2.3",


### PR DESCRIPTION
## Summary

Brings root `package.json`, all workspace modules, and `currentVersion.ts` to `3.9.1` — the highest already-published version across the fleet (cli is at 3.9.1, core at 3.9.0, most others at 3.8.4).

Establishes a clean baseline so semantic-release on the 3.x branch computes next versions without colliding with what's already on npm.

## Why

Before this, the branch had drift: root was `3.8.4`, cli `3.9.1`, core `3.9.0`, others `3.8.4`. That's fine for ad-hoc publishes but would trip the `publish-all.mjs` drift check and confuse semantic-release's version computation.

## Next steps (not in this PR)

1. After merge: `git tag v3.9.1 origin/3.x && git push origin v3.9.1` — gives semantic-release its baseline.
2. Then merge #93 (semantic-release infra).
3. Future `fix:` PR → 3.9.2, `feat:` PR → 3.10.0.

## Test plan

- [ ] Content-only diff: verify all changes are version bumps
- [ ] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)