### PR TITLE
ci: install Playwright browser in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
       - name: Build
         run: npm run build
 


### PR DESCRIPTION
## Summary
- add a Playwright browser install step to the Release workflow\n- keeps browser-based tests green in the release pipeline
## Root cause
- Release workflow ran browser-dependent tests without installing Playwright browsers.
## Validation
- npm test -- modules/monitor-browser/src/artifact-serving.test.ts modules/web-accessibility-axe/src/a11y-axe-stepper.test.ts\n