### PR TITLE
ci: fix semantic-release topology for 3.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+        run: |
+          if [ -z "$NPM_TOKEN" ]; then
+            echo "NPM_TOKEN is not set; skipping publish."
+            exit 0
+          fi
+          npx semantic-release --config release.config.mjs

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,36 +1,35 @@
 {
-	"branches": [
-		{ "name": "3.x", "range": "3.x", "channel": "latest" },
-		{ "name": "alpha", "prerelease": true },
-		{ "name": "beta", "prerelease": true },
-		{ "name": "rc", "prerelease": true }
-	],
-	"plugins": [
-		"@semantic-release/commit-analyzer",
-		"@semantic-release/release-notes-generator",
-		[
-			"@semantic-release/changelog",
-			{ "changelogFile": "CHANGELOG.md" }
-		],
-		[
-			"@semantic-release/exec",
-			{
-				"prepareCmd": "node scripts/sync-versions.mjs",
-				"publishCmd": "node scripts/publish-all.mjs ${nextRelease.channel || ''}"
-			}
-		],
-		[
-			"@semantic-release/git",
-			{
-				"assets": [
-					"CHANGELOG.md",
-					"package.json",
-					"modules/*/package.json",
-					"modules/core/src/currentVersion.ts"
-				],
-				"message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-			}
-		],
-		"@semantic-release/github"
-	]
+  "branches": [
+    "main",
+    { "name": "3.x", "range": "3.x", "channel": false },
+    { "name": "alpha", "prerelease": "alpha" }
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      { "changelogFile": "CHANGELOG.md" }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "node scripts/sync-versions.mjs",
+        "publishCmd": "node scripts/publish-all.mjs ${nextRelease.channel || ''}"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md",
+          "package.json",
+          "modules/*/package.json",
+          "modules/core/src/currentVersion.ts"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
 }


### PR DESCRIPTION
## Summary
- treat main as the release branch and 3.x as a maintenance branch
- keep alpha as the future prerelease branch
- skip publish cleanly when NPM_TOKEN is not configured

## Why
The release workflow now passes install/build/test, but semantic-release fails because 3.x alone is not a valid release topology. This change fixes the topology and prevents false-red release runs until npm credentials are configured.

## Validation
- CI=true GITHUB_TOKEN=dummy npx semantic-release --dry-run
- release workflow already passes through install/build/test
