### PR TITLE
ci: gate release on test workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,17 @@
 name: Release
 
 on:
-  push:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - 'Haibun unit tests'
+    types:
+      - completed
     branches:
       - 3.x
       - alpha
       - beta
       - rc
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -16,18 +20,21 @@ permissions:
   id-token: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: false
 
 jobs:
   release:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: true
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -39,14 +46,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browser
-        run: npx playwright install --with-deps chromium
-
       - name: Build
         run: npm run build
-
-      - name: Test
-        run: npm test
 
       - name: Release
         env:
@@ -57,4 +58,4 @@ jobs:
             echo "NPM_TOKEN is not set; skipping publish."
             exit 0
           fi
-          npx semantic-release --config release.config.mjs
+          npx semantic-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,16 @@ on:
   push:
     branches:
       - main
+      - 3.x
+      - alpha
+      - beta
+      - rc
   pull_request:
 
 permissions:
   contents: read
   pull-requests: read
 
-# This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
@@ -28,7 +31,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          # Optional: Caching npm dependencies can speed up your builds
           cache: 'npm'
 
       - name: Install main deps
@@ -37,7 +39,7 @@ jobs:
       - name: Install Playwright browsers and dependencies
         run: npx playwright install --with-deps
 
-      - name: build
+      - name: Build
         run: npm run build
 
       - name: Run tests


### PR DESCRIPTION
## Summary
- run the existing Haibun unit tests workflow on 3.x and prerelease branches
- trigger release only after that workflow completes successfully
- remove the missing release.config.mjs reference so semantic-release uses the committed config

## Testing
- workflow YAML diagnostics in VS Code