### PR TITLE
ci: order semantic-release branches for 3.x

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,7 @@
 {
   "branches": [
-    "main",
     { "name": "3.x", "range": "3.x", "channel": false },
+    "main",
     { "name": "alpha", "prerelease": "alpha" }
   ],
   "plugins": [


### PR DESCRIPTION
## Summary
- place the 3.x maintenance branch before main in semantic-release config
- keep the existing CI/release workflow unchanged
- fix EINVALIDNEXTVERSION on merge to 3.x

## Validation
- semantic-release dry-run on a local 3.x worktree no longer returns EINVALIDNEXTVERSION
- dry-run now stops only because the local 3.x validation branch is behind origin/3.x