### PR TITLE
ci: use next branch above 3.x releases

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,7 @@
 {
   "branches": [
     { "name": "3.x", "range": "3.x", "channel": false },
-    "main",
+    "next",
     { "name": "alpha", "prerelease": "alpha" }
   ],
   "plugins": [


### PR DESCRIPTION
## Summary
- stop comparing 3.x releases against main's 1.x line
- use a standard semantic-release topology of 3.x -> next -> alpha
- rely on the existing v3.9.1 baseline tag and the newly created next/alpha branches

## Validation
- semantic-release dry-run on 3.x no longer returns EINVALIDNEXTVERSION
- dry-run now only fails at the expected fake-auth push step