### PR TITLE
ci: sync root version during release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,7 +14,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "node scripts/sync-versions.mjs",
+        "prepareCmd": "node scripts/sync-versions.mjs ${nextRelease.version}",
         "publishCmd": "node scripts/publish-all.mjs ${nextRelease.channel || ''}"
       }
     ],

--- a/modules/cli/package.json
+++ b/modules/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/cli",
   "type": "module",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "command line execution for @haibun",
   "bin": {
     "haibun-cli": "build/cli.js"

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/core",
   "type": "module",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "",
   "author": "",
   "exports": {

--- a/modules/core/src/currentVersion.ts
+++ b/modules/core/src/currentVersion.ts
@@ -1,1 +1,1 @@
-export const currentVersion = '3.9.1';
+export const currentVersion = '3.9.2';

--- a/modules/domain-storage/package.json
+++ b/modules/domain-storage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/domain-storage",
   "type": "module",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/modules/lsp/package.json
+++ b/modules/lsp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/lsp",
   "type": "module",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "Language Server Protocol stepper for Haibun IDE integration",
   "main": "build/lsp-stepper.js",
   "files": [

--- a/modules/monitor-browser/package.json
+++ b/modules/monitor-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haibun/monitor-browser",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "React-based browser monitor for Haibun with shadcn/ui",
   "main": "build/index.js",
   "type": "module",

--- a/modules/monitor-otel/package.json
+++ b/modules/monitor-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haibun/monitor-otel",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "OpenTelemetry monitor for Haibun - exports traces and logs via OTLP",
   "main": "build/index.js",
   "files": [

--- a/modules/monitor-tui/package.json
+++ b/modules/monitor-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haibun/monitor-tui",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "Ink-based TUI monitor stepper for Haibun",
   "main": "build/index.js",
   "type": "module",

--- a/modules/out-junit/package.json
+++ b/modules/out-junit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/out-junit",
   "type": "module",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "",
   "files": [
     "build/**"

--- a/modules/storage-fs/package.json
+++ b/modules/storage-fs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/storage-fs",
   "type": "module",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "",
   "main": "index.js",
   "files": [

--- a/modules/storage-mem/package.json
+++ b/modules/storage-mem/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/storage-mem",
   "type": "module",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "",
   "main": "index.js",
   "files": [

--- a/modules/utils/package.json
+++ b/modules/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/utils",
   "type": "module",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "",
   "main": "index.js",
   "files": [

--- a/modules/web-accessibility-axe/package.json
+++ b/modules/web-accessibility-axe/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/web-accessibility-axe",
   "type": "module",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "",
   "main": "./build/a11y-axe-stepper.js",
   "exports": {

--- a/modules/web-http/package.json
+++ b/modules/web-http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/web-http",
   "type": "module",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "",
   "main": "build/web-http.js",
   "files": [

--- a/modules/web-playwright/package.json
+++ b/modules/web-playwright/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/web-playwright",
   "type": "module",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "",
   "main": "build/web-playwright.js",
   "exports": {

--- a/modules/web-server-hono/package.json
+++ b/modules/web-server-hono/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haibun/web-server-hono",
   "type": "module",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "Hono-based web server for haibun with MCP support",
   "main": "build/web-server-stepper.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "publish-all:beta": "node scripts/publish-all.mjs beta",
     "publish-all:rc": "node scripts/publish-all.mjs rc"
   },
-  "version": "3.9.1",
+  "version": "3.9.2",
   "overrides": {
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -13,7 +13,11 @@ import { readFileSync, writeFileSync } from "fs";
 import { execSync } from "child_process";
 
 const rootPkg = JSON.parse(readFileSync("./package.json", "utf-8"));
-const version = rootPkg.version;
+const version = process.argv[2] || rootPkg.version;
+
+rootPkg.version = version;
+writeFileSync("./package.json", JSON.stringify(rootPkg, null, 2) + "\n");
+console.info(`updated ./package.json to ${version}`);
 
 const currentVersionFile = "./modules/core/src/currentVersion.ts";
 writeFileSync(currentVersionFile, `export const currentVersion = '${version}';\n`);
@@ -29,4 +33,4 @@ for (const pkgFile of modulePkgFiles) {
 	console.info(`updated ${pkg.name} to ${version}`);
 }
 
-execSync(`git add ${currentVersionFile} ${modulePkgFiles.join(" ")}`, { stdio: "inherit" });
+execSync(`git add ./package.json ${currentVersionFile} ${modulePkgFiles.join(" ")}`, { stdio: "inherit" });


### PR DESCRIPTION
## Summary
- pass nextRelease.version into the release prepare step
- update the root package version alongside module manifests and currentVersion.ts
- keep 3.x release files aligned with the published semantic-release version

## Validation
- running node scripts/sync-versions.mjs 3.9.2 updates the root package and all module versions together
- the current branch changes confirm 3.9.2 file drift existed and are included here