### PR TITLE
ci: release workflow uses a GitHub App token for git push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,19 @@ jobs:
       id-token: write
 
     steps:
+      - name: Generate release-app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Use Node.js 24
         uses: actions/setup-node@v4
@@ -86,13 +94,13 @@ jobs:
       - name: Verify environment
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
         run: bash scripts/verify-environment.sh
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [ -z "$NODE_AUTH_TOKEN" ]; then


### PR DESCRIPTION
## Summary

- `release` job now obtains a token from a GitHub App via `actions/create-github-app-token@v1` and uses it for checkout, `verify-environment`, and the `Release` step.
- The default `GITHUB_TOKEN` is no longer used for the git push that `@semantic-release/git` performs at the end of a release.

## Why

The `3.x` branch ruleset requires changes through a PR. `@semantic-release/git` pushes a commit (CHANGELOG.md + version-sync files) directly to `3.x` at release time, which the ruleset rejects with `GH013` when the push is signed by the default `GITHUB_TOKEN` (the `github-actions[bot]` actor isn't in any selectable bypass slot on this plan tier).

Switching the push to act as a GitHub App lets the App be added to the ruleset's Bypass list while the PR-only requirement still applies to all human contributors.

## Required configuration before this can run

- A GitHub App installed on `withhaibun/haibun` with **Contents: Read and write**, **Pull requests: Read and write**, **Issues: Read and write**.
- Repo secrets: `RELEASE_APP_ID` (App's numeric ID) and `RELEASE_APP_PRIVATE_KEY` (full `.pem` contents).
- The App added to the `3.x` ruleset's **Bypass list**.

## Test plan

- [ ] After merge to `3.x`, the release run completes the `prepare` step of `@semantic-release/git` without `GH013`.
- [ ] The release tag, GitHub Release, and npm publish all complete as before.
- [ ] The CHANGELOG/version-sync commit lands on `3.x` and is attributed to the App.