### PR TITLE
ci: diagnose app token identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,19 @@ jobs:
           REPO: ${{ github.repository }}
         run: bash scripts/verify-environment.sh
 
+      - name: Diagnose app token identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "=== /installation/repositories (token's installation scope) ==="
+          gh api /installation/repositories --jq '{total_count, repositories: [.repositories[].full_name]}' || true
+          echo "=== /repos/${{ github.repository }} permissions (what this token can do here) ==="
+          gh api /repos/${{ github.repository }} --jq '.permissions' || true
+          echo "=== app slug / id resolved from this token ==="
+          gh api /app --jq '{id, slug, name, owner: .owner.login}' || true
+          echo "=== ruleset bypass actors as seen via this token ==="
+          gh api /repos/${{ github.repository }}/rulesets/3116695 --jq '.bypass_actors' || true
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Print App token identity + repo permissions + ruleset bypass actors so we can see why pushes are still rejected with GH013 despite haibun-release-bot being on the bypass list. Strictly diagnostic — no behavior change to release pipeline.