### PR TITLE
ci: add manual publish-all workflow

### DIFF
--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -1,0 +1,46 @@
+name: 'Publish all (manual)'
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'npm dist-tag (omit for @latest)'
+        required: false
+        default: ''
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'npm'
+          registry-url: https://registry.npmjs.org
+
+      - name: Remove deprecated npm always-auth config
+        run: npm config delete always-auth || true
+
+      - name: Install main deps
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish all modules
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "ERROR: NPM_TOKEN is not set; cannot publish."
+            exit 1
+          fi
+          node scripts/publish-all.mjs '${{ inputs.tag }}'


### PR DESCRIPTION
Adds a workflow_dispatch job that runs scripts/publish-all.mjs with the NPM_TOKEN secret. Lets us (re)publish from CI without a local setup — needed because the latest release ran semantic-release/git successfully (v3.9.4 tag + chore(release) commit landed on 3.x) but the npm publish step failed for all 15 packages with HTTP 404. After the NPM_TOKEN is renewed, run this workflow against 3.x to backfill the v3.9.4 publish.