### PR TITLE
ci: enable 4.x as next-major prerelease branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           npm test
 
   release:
-    if: ${{ github.event_name == 'push' && contains(fromJSON('["3.x","alpha","beta","rc"]'), github.ref_name) }}
+    if: ${{ github.event_name == 'push' && contains(fromJSON('["3.x","4.x","alpha","beta","rc"]'), github.ref_name) }}
     needs: test
     runs-on: ubuntu-latest
     permissions:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,7 @@
 {
   "branches": [
     { "name": "3.x", "range": "3.x", "channel": false },
-    "next",
+    { "name": "4.x", "prerelease": "next" },
     { "name": "alpha", "prerelease": "alpha" }
   ],
   "plugins": [


### PR DESCRIPTION
Adds 4.x to both release gates:

- `.releaserc.json` branches: `{ "name": "4.x", "prerelease": "next" }` — replaces the unused bare `next` entry. Commits on 4.x produce `v4.0.0-next.N` etc.
- `ci.yml` release-job filter: adds `4.x` to the allowed branches list

Result: pushes to 4.x trigger the release job; semantic-release publishes prereleases to npm under the `@next` dist-tag. `@latest` stays on 3.x — 4.x is dev / next-major, not production.

The `alpha` entry is kept as-is; can be retired in a follow-up if the alpha branch is no longer used.